### PR TITLE
Setting Ports & Host correctly for local dev

### DIFF
--- a/App-Template/Dockerfile
+++ b/App-Template/Dockerfile
@@ -30,7 +30,7 @@ ENV PATH /usr/src/app/bin:$PATH
 RUN bundle config --global silence_root_warning 1
 
 EXPOSE 3000
-CMD ["bundle", "exec", "hanami", "server", "-b", "0.0.0.0", "-p", "3000"]
+CMD ["bundle", "exec", "hanami", "server", "--host=0.0.0.0", "--port=3000"]
 
 FROM development AS production
 

--- a/App-Template/docker-compose.yml
+++ b/App-Template/docker-compose.yml
@@ -73,7 +73,7 @@ services:
 
   web:
     <<: *app
-    command: bash -c "rm -rf /usr/src/app/tmp/pids/server.pid && bundle exec hanami server -p 3000 -b '0.0.0.0'"
+    command: bash -c "rm -rf /usr/src/app/tmp/pids/server.pid && bundle exec hanami server --port=3000 --host=0.0.0.0"
     ports:
       - "${PORT:-3000}:3000"
 


### PR DESCRIPTION
Hanani uses `--port` & `--host` over `-p`/`-b`.