### PR TITLE
Retagging satackey/action-docker-layer-caching to v0

### DIFF
--- a/.github/workflows/update-template-repo.yml
+++ b/.github/workflows/update-template-repo.yml
@@ -65,7 +65,7 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/App
         docker-compose pull
-    - uses: satackey/action-docker-layer-caching@v0.0.10
+    - uses: satackey/action-docker-layer-caching@v0
     - name: Test we can build docker
       run: |
         cd $GITHUB_WORKSPACE/App


### PR DESCRIPTION
I want to reduce the amount of notifications down a little, so defaulting to `v0`